### PR TITLE
v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.3.1
+
+- Optimize: avoid use of `Element.attributes` to find a matching attribute (`RegExp` or case-insensitive).
+
+- async_extension: ^1.2.12
+- test: ^1.25.7
+
 ## 2.3.0
 
 - sdk: '>=3.3.0 <4.0.0'

--- a/lib/src/dom_tools_base.dart
+++ b/lib/src/dom_tools_base.dart
@@ -707,11 +707,9 @@ String? getElementAttribute(Element element, Object? key) {
 
 /// Returns [element] attribute with [RegExp] [key].
 String? getElementAttributeRegExp(Element element, RegExp key) {
-  var attrs = element.attributes;
-
-  for (var k in attrs.keys) {
+  for (var k in element.getAttributeNames()) {
     if (key.hasMatch(k)) {
-      return attrs[k];
+      return element.getAttribute(k);
     }
   }
 
@@ -723,14 +721,11 @@ String? getElementAttributeStr(Element element, String key) {
   var val = element.getAttribute(key);
   if (val != null) return val;
 
-  key = key.trim();
-  key = key.toLowerCase();
+  key = key.trim().toLowerCase();
 
-  var attrs = element.attributes;
-
-  for (var k in attrs.keys) {
+  for (var k in element.getAttributeNames()) {
     if (k.toLowerCase() == key) {
-      return attrs[k];
+      return element.getAttribute(k);
     }
   }
 
@@ -757,8 +752,8 @@ String _toHTMLAny(Element e) {
   html += '<';
   html += e.tagName;
 
-  for (var attr in e.attributes.keys) {
-    var val = e.attributes[attr];
+  for (var attr in e.getAttributeNames()) {
+    var val = e.getAttribute(attr);
     if (val != null) {
       if (val.contains("'")) {
         html += ' attr="$val"';

--- a/lib/src/dom_tools_extension.dart
+++ b/lib/src/dom_tools_extension.dart
@@ -1,7 +1,5 @@
 import 'dart:html';
 
-import 'package:collection/collection.dart';
-
 extension DomElementExtension on Element {
   /// Alias to [querySelector] casting to [T].
   T? querySelectorTyped<T extends Element>(String selectors) {
@@ -23,9 +21,9 @@ extension DomElementExtension on Element {
 
   /// Selects the [AnchorElement] links.
   List<String> selectAnchorLinks() =>
-      selectAnchorElements().map((e) => e.href).whereNotNull().toList();
+      selectAnchorElements().map((e) => e.href).nonNulls.toList();
 
-  /// Selects the [AnchorElement] links targets/fragmets.
+  /// Selects the [AnchorElement] links targets/fragments.
   List<String> selectAnchorLinksTargets() => selectAnchorLinks()
       .where((e) => e.contains('#'))
       .map((e) => e.split('#').last)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dom_tools
 description: DOM rich elements and tools for CSS, JavaScript, Element Tracking, DOM Manipulation, Storage, Dialog and more.
-version: 2.3.0
+version: 2.3.1
 homepage: https://github.com/gmpassos/dom_tools
 
 environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
-  async_extension: ^1.2.5
+  async_extension: ^1.2.12
   intl: ^0.19.0
   json_object_mapper: ^2.0.1
   swiss_knife: ^3.2.0
@@ -17,7 +17,7 @@ dependencies:
 
 dev_dependencies:
   lints: ^3.0.0
-  test: ^1.25.2
+  test: ^1.25.7
   dependency_validator: ^3.2.3
 
 #dependency_overrides:


### PR DESCRIPTION
- Optimize: avoid use of `Element.attributes` to find a matching attribute (`RegExp` or case-insensitive).

- async_extension: ^1.2.12
- test: ^1.25.7