### PR TITLE
v3.0.0-beta.17 - swiss_knife: ^3.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.0.0-beta.17
+
+- `DOMTreeReferenceMap`:
+  - Added generic constraint `V extends Object`.
+  - Added support for `autoPurgeThreshold` and `onPurgedEntries` parameters in constructor.
+
+- Dependencies:
+  - Updated `swiss_knife` from ^3.3.3 to ^3.3.4.
+
 ## 3.0.0-beta.16
 
 - `dom_tools_file.dart`:

--- a/bump.sh
+++ b/bump.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+APIKEY=$1
+shift  # remove the first argument (API key) from "$@"
+
+## dart pub global activate dart_bump
+
+dart_bump . \
+  --api-key $APIKEY \
+  "$@"

--- a/lib/src/dom_tools_base.dart
+++ b/lib/src/dom_tools_base.dart
@@ -1161,12 +1161,14 @@ Element? getParentElement(Element element,
 }
 
 /// A [TreeReferenceMap] for DOM Nodes.
-class DOMTreeReferenceMap<V> extends TreeReferenceMap<Node, V> {
+class DOMTreeReferenceMap<V extends Object> extends TreeReferenceMap<Node, V> {
   DOMTreeReferenceMap(super.root,
       {super.autoPurge,
+      super.autoPurgeThreshold,
       super.keepPurgedKeys,
       super.purgedEntriesTimeout,
-      super.maxPurgedEntries});
+      super.maxPurgedEntries,
+      super.onPurgedEntries});
 
   @override
   bool isInTree(Node? key) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dom_tools
 description: DOM rich elements and tools for CSS, JavaScript, Element Tracking, DOM Manipulation, Storage, Dialog and more.
-version: 3.0.0-beta.16
+version: 3.0.0-beta.17
 homepage: https://github.com/gmpassos/dom_tools
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   js_interop_utils: ^1.0.9
   async_extension: ^1.2.20
   intl: ^0.20.2
-  swiss_knife: ^3.3.3
+  swiss_knife: ^3.3.4
   markdown: ^6.0.1
   collection: ^1.19.1
   web: ^1.1.1


### PR DESCRIPTION
- `DOMTreeReferenceMap`:
  - Added generic constraint `V extends Object`.
  - Added support for `autoPurgeThreshold` and `onPurgedEntries` parameters in constructor.

- Dependencies:
  - Updated `swiss_knife` from ^3.3.3 to ^3.3.4.