### PR TITLE
v3.0.0-beta.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.0.0-beta.18
+
+- `getElementAttributeStr`:
+  - Fixed redundant case-insensitive attribute lookup by relying on `Element.getAttribute()` which is case-insensitive.
+
+- Dependency updates:
+  - `web_utils`: ^1.0.20
+
 ## 3.0.0-beta.17
 
 - `DOMTreeReferenceMap`:

--- a/lib/src/dom_tools_base.dart
+++ b/lib/src/dom_tools_base.dart
@@ -645,18 +645,9 @@ String? getElementAttributeRegExp(Element element, RegExp key) {
 
 /// Returns [element] attribute with [String] [key].
 String? getElementAttributeStr(Element element, String key) {
+  // `Element.getAttribute()` is case-insensitive
   var val = element.getAttribute(key);
-  if (val != null) return val;
-
-  key = key.trim().toLowerCase();
-
-  for (var k in element.getAttributeNames().toList()) {
-    if (k.toLowerCase() == key) {
-      return element.getAttribute(k);
-    }
-  }
-
-  return null;
+  return val;
 }
 
 /// Clears selected text in vieport.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: dom_tools
 description: DOM rich elements and tools for CSS, JavaScript, Element Tracking, DOM Manipulation, Storage, Dialog and more.
-version: 3.0.0-beta.17
+version: 3.0.0-beta.18
 homepage: https://github.com/gmpassos/dom_tools
 
 environment:
   sdk: '>=3.6.0 <4.0.0'
 
 dependencies:
-  web_utils: ^1.0.19
+  web_utils: ^1.0.20
   js_interop_utils: ^1.0.9
   async_extension: ^1.2.20
   intl: ^0.20.2


### PR DESCRIPTION
- `getElementAttributeStr`:
  - Fixed redundant case-insensitive attribute lookup by relying on `Element.getAttribute()` which is case-insensitive.

- Dependency updates:
  - `web_utils`: ^1.0.20